### PR TITLE
Fix bottleneck when draging files from the result list.

### DIFF
--- a/src/gsearchtool-callbacks.c
+++ b/src/gsearchtool-callbacks.c
@@ -1550,11 +1550,6 @@ drag_file_cb  (GtkWidget * widget,
 			else {
 				uri_list = g_strconcat (uri_list, "\n", tmp_uri, NULL);
 			}
-			gtk_selection_data_set (selection_data,
-			                        gtk_selection_data_get_target (selection_data),
-			                        8,
-			                        (guchar *) uri_list,
-			                        strlen (uri_list));
 			g_free (tmp_uri);
 		}
 		else {
@@ -1563,6 +1558,15 @@ drag_file_cb  (GtkWidget * widget,
 		g_free (utf8_name);
 		g_free (locale_file);
 	}
+
+	if (uri_list) {
+		gtk_selection_data_set (selection_data,
+		                        gtk_selection_data_get_target (selection_data),
+		                        8,
+		                        (guchar *) uri_list,
+		                        strlen (uri_list));
+	}
+
 	g_list_foreach (list, (GFunc) gtk_tree_path_free, NULL);
 	g_list_free (list);
 	g_free (uri_list);


### PR DESCRIPTION
This speeds up retrieving the draged uris from gnome-search-tool. 

If you have a long list of files, lets say 1000, the original code allocates 1000 times a new buffer and frees 999 of them. 
Now it uses only one allocation. 

However the drag data seams to have size limit. In my test I have 2700 files in the result window, which produces a result string of 341351 bytes. The target application can only read 8 bytes from the X server, using XGetWindowProperty. Do you know if there is a limit and if there is one how to find out how big it is? 

This was tested on Ubuntu Trusty.
